### PR TITLE
Add documentation for network during setup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ Dependencies:
 - Docker
 - [Multipass](https://multipass.run/)
 - jq
+- internet connectivity during installation. If you intend to run this from behind a corporate proxy, you may be unable to pull the required images for k3s or Spinnaker. Also you may need to disable any desktop firewalls which are running whilst you perform the installation. 
 
 **Steps**
 


### PR DESCRIPTION
Setup requires that you have full access to pull images etc from internet. It may also require that the firewall be disabled